### PR TITLE
Add libnice

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This image comes in many flavours, based on different Ubuntu releases and packag
 | FLAC      | 1.3.2         | 1.3.2  |
 | Opus      | 1.1.2         | 1.1.2  |
 | libsrtp2  | -             | 2.3.0  |
+| libnice   | -             | master |
 
 ### Version selection
 

--- a/README.md
+++ b/README.md
@@ -14,19 +14,19 @@ This image comes in many flavours, based on different Ubuntu releases and packag
 
 ## Package versions
 
-| Package   | bionic        | focal  |
-| --------- | ------------- | ------ |
-| Erlang    | 21.3 and 22.2 | 22.3   |
-| Elixir    | 1.9.4         | 1.10.3 |
-| FFmpeg    | 4.2.2         | 4.2.2  |
-| SDL2      | ?             | ?      |
-| FDK AAC   | 2.0           | 2.0    |
-| Portaudio | 19.6.0        | 19.6.0 |
-| MAD       | 0.15.1        | 0.15.1 |
-| FLAC      | 1.3.2         | 1.3.2  |
-| Opus      | 1.1.2         | 1.1.2  |
-| libsrtp2  | -             | 2.3.0  |
-| libnice   | -             | master |
+| Package   | bionic        | focal            |
+| --------- | ------------- | -----------------|
+| Erlang    | 21.3 and 22.2 | 22.3             |
+| Elixir    | 1.9.4         | 1.10.3           |
+| FFmpeg    | 4.2.2         | 4.2.2            |
+| SDL2      | ?             | ?                |
+| FDK AAC   | 2.0           | 2.0              |
+| Portaudio | 19.6.0        | 19.6.0           |
+| MAD       | 0.15.1        | 0.15.1           |
+| FLAC      | 1.3.2         | 1.3.2            |
+| Opus      | 1.1.2         | 1.1.2            |
+| libsrtp2  | -             | 2.3.0  	       |
+| libnice   | -             | master (833c1aa) |
 
 ### Version selection
 

--- a/focal/Dockerfile
+++ b/focal/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update \
     gcc-9 \
     git \
     libffi-dev \
+    libglib2.0-dev \
     libncurses-dev \
     libreadline-dev \
     libssl-dev \
@@ -25,12 +26,23 @@ RUN apt-get update \
     libxslt-dev \
     libyaml-dev \
     locales \
+    meson \
+    ninja-build \
     unixodbc-dev \
     unzip \
     wget \
  && rm -rf /var/lib/apt/lists/* \
  && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 \
  && git clone https://github.com/asdf-vm/asdf.git /root/.asdf -b v0.7.8
+
+# libnice
+RUN git clone https://github.com/libnice/libnice.git \
+ && cd libnice/ \
+ && meson builddir \
+ && ninja -C builddir \
+ && ninja -C builddir test \
+ && ninja -C builddir install \
+ && cd /
 
 ENV LANG en_US.utf8
 

--- a/focal/Dockerfile
+++ b/focal/Dockerfile
@@ -36,8 +36,12 @@ RUN apt-get update \
  && git clone https://github.com/asdf-vm/asdf.git /root/.asdf -b v0.7.8
 
 # libnice
+# Building from source has been choosen because of potential bug described in
+# https://gitlab.freedesktop.org/libnice/libnice/-/issues/120. Even after fixing it the new version
+# will not probably be available in apt repositories for some time.
 RUN git clone https://github.com/libnice/libnice.git \
  && cd libnice/ \
+ && git checkout 833c1aa4cc442f2e25216dc411651a674d36c09a \
  && meson builddir \
  && ninja -C builddir \
  && ninja -C builddir test \


### PR DESCRIPTION
Adds libnice built from master. Building from source has been choosen because of potential bug described in  [#120](https://gitlab.freedesktop.org/libnice/libnice/-/issues/120). Even after fixing it the new version will not probably be available in apt repositories for some time.